### PR TITLE
Support for 'binmode' (to set PerlIO layers, esp. encoding).

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,6 +15,7 @@ Monkey::Patch::Action=0
 tainting=0.01
 Test::Exception=0.31
 Test::More=0.98
+Test::Warnings=0.14
 
 [Prereqs]
 perl=5.010001

--- a/lib/File/Write/Rotate.pm
+++ b/lib/File/Write/Rotate.pm
@@ -195,6 +195,10 @@ sub _open {
 
     my $fp = $self->file_path;
     open $self->{_fh}, ">>", $fp or die "Can't open '$fp': $!";
+    if (defined $self->{binmode}) {
+        binmode $self->{_fh}, $self->{binmode}
+            or die "Can't set PerlIO layer on '$fp': $!";
+    }
     my $oldfh = select $self->{_fh}; $| = 1; select $oldfh; # set autoflush
     $self->{_fp} = $fp;
 }


### PR DESCRIPTION
When logging UTF-8 encoded messages with Log::Dispatch::FileWriteRotate, we receive warnings like this:

Wide character in print at /.../File/Write/Rotate.pm line 277, <$file> line 35.

The solution would be to set the PerlIO layer on the underlying filehandle to something that matches the encoding of the messages (ie. ':utf8' or ':encoding(UTF-8)'). This commit makes that possible.

I chose the 'binmode' name for the attribute so that it would be consistent with Log::Dispatch::FileRotate / Log::Dispatch::File (and also b/c that's what it does under the hood).
